### PR TITLE
Change things to use the end of an interval rather than the beginning. I think this is more intuitive.

### DIFF
--- a/src/lib/chartstack.js
+++ b/src/lib/chartstack.js
@@ -4215,7 +4215,7 @@ Dataform.prototype.sort = function(opts){
         if (response.result.length > 0 && response.result[0]['timeframe']) {
           // Get index (start time)
           schema.unpack.index = {
-            path: "timeframe -> start",
+            path: "timeframe -> end",
             type: "date",
             //format: "MMM DD"
             method: "moment"

--- a/src/plugins/keen-chartstack.js
+++ b/src/plugins/keen-chartstack.js
@@ -81,7 +81,7 @@
             collection: "result",
             select: [
               {
-                path: "timeframe -> start",
+                path: "timeframe -> end",
                 type: "date"
               },
               {
@@ -133,7 +133,7 @@
             collection: "result",
             unpack: {
               index: {
-                path: "timeframe -> start",
+                path: "timeframe -> end",
                 type: "date"
               },
               value: {
@@ -319,7 +319,7 @@
         };
         if (isInterval) {
           datasetConfig.schema.unpack = {
-            index: 'timeframe -> start',
+            index: 'timeframe -> end',
             label: 'value -> ' + req.queries[0].params.group_by[0],
             value: 'value -> result'
           };


### PR DESCRIPTION
Not sure how to test this or if it's right in all cases. Definitely better for things like weekly intervals. Shouldn't matter much for daily and such. I think the "common" case is that people want to see the date or time that the interval ended?
