### PR TITLE
Improved trackExternalLink method

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -11,23 +11,27 @@
   Keen.prototype.trackExternalLink = function(jsEvent, eventCollection, payload, timeout, timeoutCallback){
 
     var evt = jsEvent,
-        target = evt.currentTarget || evt.srcElement || evt.target,
+        target = (evt.currentTarget) ? evt.currentTarget : (evt.srcElement || evt.target),
         timer = timeout || 500,
         triggered = false,
-        targetAttr,
+        targetAttr = "",
         callback,
         win;
 
-    targetAttr = target.getAttribute("target") || target.target || "";
+    if (target.getAttribute !== void 0) {
+      targetAttr = target.getAttribute("target");
+    } else if (target.target) {
+      targetAttr = target.target;
+    }
 
-    if (targetAttr == "_blank" && !evt.metaKey) {
+    if ((targetAttr == "_blank" || targetAttr == "blank") && !evt.metaKey) {
       win = window.open("about:blank");
       win.document.location = target.href;
     }
 
     if (target.nodeName === "A") {
       callback = function(){
-        if(!triggered && !evt.metaKey && targetAttr !== "_blank"){
+        if(!triggered && !evt.metaKey && (targetAttr !== "_blank" && targetAttr !== "blank")){
           triggered = true;
           window.location = target.href;
         }
@@ -39,6 +43,8 @@
           target.submit();
         }
       };
+    } else {
+      Keen.log("#trackExternalLink method not attached to an <a> or <form> DOM element");
     }
 
     if (timeoutCallback) {


### PR DESCRIPTION
- Print warnings when triggered on incorrect DOM elements, closes #95
- Improved handling of event properties on older browsers
