### PR TITLE
Fix base class / prototype chain when creating new visualization types

### DIFF
--- a/src/visualize.js
+++ b/src/visualize.js
@@ -64,17 +64,8 @@
   };
 
   function _build_visual(selector, config){
-    this.visual = new Keen.Visualization(this, selector, config);
+    this.visual = Keen.Visualization.render(this, selector, config);
   }
-
-
-  // -------------------------------
-  // Keen.Visualization
-  // -------------------------------
-  Keen.Visualization = function(dataset, el, config){
-    var chartType = (config && config.chartType) ? config.chartType : null;
-    return new Keen.Dataviz(chartType).prepare(el).setData(dataset).setConfig(config).render(el);
-  };
 
   // *******************
   // START NEW CLEAN API
@@ -370,6 +361,38 @@
     }
   };
 
+  // -------------------------------
+  // Keen.Visualization
+  // -------------------------------
+  var baseVisualization = Keen.Visualization = function(config){
+    var self = this;
+    _extend(self, config);
+
+    // Set default event handlers
+    self.on("error", function(){
+      var errorConfig, error;
+      errorConfig = Keen.utils.extend({
+        error: { message: arguments[0] }
+      }, config);
+      error = new Keen.Visualization.libraries['keen-io']['error'](errorConfig);
+    });
+    self.on("update", function(){
+      self.update.apply(this, arguments);
+    });
+    self.on("remove", function(){
+      self.remove.apply(this, arguments);
+    });
+
+    // Let's kick it off!
+    self.initialize();
+    Keen.Visualization.visuals.push(self);
+  };
+
+  Keen.Visualization.render = function(dataset, el, config){
+    var chartType = (config && config.chartType) ? config.chartType : null;
+    return new Keen.Dataviz(chartType).prepare(el).setData(dataset).setConfig(config).render(el);
+  };
+
   // Visual defaults
   Keen.Visualization.defaults = {
     library: 'google',
@@ -399,29 +422,6 @@
   };
 
   Keen.Visualization.visuals = [];
-  var baseVisualization = function(config){
-    var self = this;
-    _extend(self, config);
-
-    // Set default event handlers
-    self.on("error", function(){
-      var errorConfig, error;
-      errorConfig = Keen.utils.extend({
-        error: { message: arguments[0] }
-      }, config);
-      error = new Keen.Visualization.libraries['keen-io']['error'](errorConfig);
-    });
-    self.on("update", function(){
-      self.update.apply(this, arguments);
-    });
-    self.on("remove", function(){
-      self.remove.apply(this, arguments);
-    });
-
-    // Let's kick it off!
-    self.initialize();
-    Keen.Visualization.visuals.push(self);
-  };
 
   baseVisualization.prototype = {
     initialize: function(){

--- a/src/viz-sketch.js
+++ b/src/viz-sketch.js
@@ -4,7 +4,7 @@ var el = document.getElementById("chart-wrapper");
 
 client.draw(query, el, {});
 
-var chart = new Keen.Visualization([req||raw],el,{
+var chart = Keen.Visualization.render([req||raw],el,{
   chartType: "piechart",
   library: "google",
   labelMapping: {

--- a/test/examples/visualize/index.html
+++ b/test/examples/visualize/index.html
@@ -205,7 +205,7 @@
         });
         console.log(data, labelMap);
 
-        new Keen.Visualization(data, document.getElementById("funnel"), {
+        Keen.Visualization.render(data, document.getElementById("funnel"), {
           library: "google",
           chartType: "barchart",
           labelMapping: labelMap
@@ -234,7 +234,7 @@
         });
       });
 
-      window.chart = new Keen.Visualization({ result: 24450 }, document.getElementById("chart2"), {
+      window.chart = Keen.Visualization.render({ result: 24450 }, document.getElementById("chart2"), {
         chartType: 'metric',
         title: "Manual!",
         width: 600,
@@ -245,7 +245,7 @@
         colors: ['#222']
       });
 
-      window.chart = new Keen.Visualization({ result: 78524450 }, document.getElementById("metric2"), {
+      window.chart = Keen.Visualization.render({ result: 78524450 }, document.getElementById("metric2"), {
         chartType: 'metric',
         title: "Two!",
         width: "auto",
@@ -286,7 +286,7 @@
         this.data = newData;
 
         if (window.memChart) window.memChart.remove();
-        window.memChart = new Keen.Visualization(this, document.getElementById("random-multi-js"), {
+        window.memChart = Keen.Visualization.render(this, document.getElementById("random-multi-js"), {
           library: "google",
           chartType: "linechart",
           title: "Random multi",
@@ -359,7 +359,7 @@
               col2 : Math.floor(test_max / 2) - i
           });
       }
-      var testsort = new Keen.Visualization({
+      var testsort = Keen.Visualization.render({
           result : test_rows
       }, document.getElementById('test-table-sort'), {
           chartType : 'table',


### PR DESCRIPTION
Alternative B to #143 . Renames `Keen.Visualization()` to `Keen.Visualization.render
()`, and `baseVisualization` to `Keen.Visualization`. This would be a breaking change.
