### PR TITLE
Unnecessary return statement

### DIFF
--- a/src/dataset/dataset.js
+++ b/src/dataset/dataset.js
@@ -329,4 +329,3 @@ function extend(o, e){
 }
 
 module.exports = Dataset;
-return;


### PR DESCRIPTION
An unnecessary return statement in dataset/dataset.js causes a parsing error in webpack