### PR TITLE
browserify-versionify@1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "browserify-versionify": "^1.0.3",
+    "browserify-versionify": "1.0.3",
     "component-emitter": "^1.1.3",
     "domready": "0.3.0",
     "JSON2": "^0.1.0",


### PR DESCRIPTION
It looks like browserify-versionify released a breaking change yesterday as version 1.0.4.
https://github.com/webpro/versionify/commits/master

And now I'm seeing this error:

```
.../node_modules/keen-js/node_modules/browserify-versionify/node_modules/find-root/index.js:13
    throw new Error('package.json not found in path')
          ^
Error: package.json not found in path
```

Locking the version to 1.0.3 resolves the issue for me.