### PR TITLE
fixed doc typo for saving multiple events

### DIFF
--- a/docs/track.md
+++ b/docs/track.md
@@ -74,7 +74,7 @@ client.addEvents(multipleEvents, function(err, res){
 });
 ```
 
-### API response for saving a single event
+### API response for saving multiple events
 
 ```json
 {


### PR DESCRIPTION
noticed a typo in one of your docs...

#### What does this PR do?

fixes a typo in docs/track.md to correctly reference the sample response for tracking multiple events

#### How should this be manually tested?

n/a

#### Are there any related issues open?

no issue open

#### Screenshots (if appropriate)

n/a