### PR TITLE
Url encoding event name before building url

### DIFF
--- a/src/core/lib/addEvent.js
+++ b/src/core/lib/addEvent.js
@@ -14,7 +14,7 @@ var base64 = require('../utils/base64'),
 
 module.exports = function(collection, payload, callback, async) {
   var self = this,
-      urlBase = this.url('/events/' + collection),
+      urlBase = this.url('/events/' + encodeURIComponent(collection)),
       reqType = this.config.requestType,
       data = {},
       cb = callback,


### PR DESCRIPTION
This commit fixes #264 