### PR TITLE
Add keen-query.js - only loads what's required to making queries to Keen.io

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,8 @@ gulp.task('build', ['build:browserify', 'build:minify']);
 gulp.task('build:browserify', function() {
   return gulp.src([
       './src/keen.js',
-      './src/keen-tracker.js'
+      './src/keen-tracker.js',
+      './src/keen-query.js'
     ])
     .pipe(transform(function(filename) {
       var b = browserify(filename);
@@ -38,7 +39,8 @@ gulp.task('build:browserify', function() {
 gulp.task('build:minify', ['build:browserify'], function(){
   return gulp.src([
       './dist/keen.js',
-      './dist/keen-tracker.js'
+      './dist/keen-tracker.js',
+      './dist/keen-query.js'
       // './src/loader.js'
     ])
     .pipe(compress({ type: 'js' }))
@@ -175,7 +177,9 @@ gulp.task('aws', ['build', 'test:local'], function() {
       './dist/keen.js',
       './dist/keen.min.js',
       './dist/keen-tracker.js',
-      './dist/keen-tracker.min.js'
+      './dist/keen-tracker.min.js',
+      './dist/keen-query.js',
+      './dist/keen-query.min.js'
     ])
     .pipe(rename(function(path) {
       path.dirname += '/' + pkg['version'];

--- a/src/keen-query.js
+++ b/src/keen-query.js
@@ -1,0 +1,46 @@
+;(function (f) {
+  // RequireJS
+  if (typeof define === "function" && define.amd) {
+    define("keen", [], function(){ return f(); });
+  }
+  // CommonJS
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f();
+  }
+  // Global
+  var g = null;
+  if (typeof window !== "undefined") {
+    g = window;
+  } else if (typeof global !== "undefined") {
+    g = global;
+  } else if (typeof self !== "undefined") {
+    g = self;
+  }
+  if (g) {
+    g.Keen = f();
+  }
+})(function() {
+  "use strict";
+
+  var Keen = require("./core"),
+      extend = require("./core/utils/extend");
+
+  extend(Keen.prototype, {
+    "get"                 : require("./core/lib/get"),
+    "run"                 : require("./core/lib/run")
+  });
+
+  Keen.Query = require("./core/query");
+  Keen.Request = require("./core/request");
+
+  Keen.utils = {
+    "each"         : require("./core/utils/each"),
+    "extend"       : extend,
+    "parseParams"  : require("./core/utils/parseParams"),
+  };
+
+  Keen.emit("ready");
+
+  module.exports = Keen;
+  return Keen;
+});


### PR DESCRIPTION
#### What does this PR do?

* Adds keen-query.js - which just loads stuff required for making queries. Without loading google api, or other stuff

#### How should this be manually tested?

* requiring keen-query.js and using Keen.query should just work

#### Are there any related issues open?

Relates #217
