### PR TITLE
Keen.Dataset improvements

### DIFF
--- a/src/dataset/dataset.js
+++ b/src/dataset/dataset.js
@@ -8,7 +8,7 @@ var Emitter = require('../core/helpers/emitter-shim');
 function Dataset(){
   this.data = {
     input: {},
-    output: [[]]
+    output: [['index']]
   };
   this.meta = {
     schema: {},

--- a/src/dataset/index.js
+++ b/src/dataset/index.js
@@ -6,6 +6,7 @@ extend(Dataset.prototype, require("./lib/delete"));
 extend(Dataset.prototype, require("./lib/filter"));
 extend(Dataset.prototype, require("./lib/insert"));
 extend(Dataset.prototype, require("./lib/select"));
+extend(Dataset.prototype, require("./lib/set"));
 extend(Dataset.prototype, require("./lib/sort"));
 extend(Dataset.prototype, require("./lib/update"));
 

--- a/src/dataset/lib/append.js
+++ b/src/dataset/lib/append.js
@@ -1,4 +1,5 @@
 var each = require("../../core/utils/each");
+var createNullList = require('../utils/create-null-list');
 
 module.exports = {
   "appendColumn": appendColumn,
@@ -26,18 +27,30 @@ function appendColumn(str, input){
 
   else if (!input || input instanceof Array) {
     self.data.output[0].push(label);
-    each(self.output(), function(row, i){
-      var cell;
-      if (i > 0) {
-        cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
-        self.data.output[i].push(cell);
-      }
+    input = input || [];
+
+    if (input.length <= self.output().length - 1) {
+      input = input.concat( createNullList(self.output().length - 1 - input.length) );
+    }
+    else {
+      // If this new column is longer than existing columns,
+      // we need to update the rest to match ...
+      each(input, function(value, i){
+        if (self.data.output.length -1 < input.length) {
+          appendRow.call(self, String( self.data.output.length ));
+        }
+      });
+    }
+
+    each(input, function(value, i){
+      self.data.output[i+1][self.data.output[0].length-1] = value;
     });
 
   }
 
   return self;
 }
+
 
 function appendRow(str, input){
   var self = this,
@@ -48,7 +61,7 @@ function appendRow(str, input){
   newRow.push(label);
 
   if (typeof input === "function") {
-    each(self.output()[0], function(label, i){
+    each(self.data.output[0], function(label, i){
       var col, cell;
       if (i > 0) {
         col = self.selectColumn(i);
@@ -63,15 +76,21 @@ function appendRow(str, input){
   }
 
   else if (!input || input instanceof Array) {
-    each(self.output()[0], function(label, i){
-      var cell;
-      if (i > 0) {
-        cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
-        newRow.push(cell);
-      }
-    });
-    this.data.output.push(newRow);
+    input = input || [];
+
+    if (input.length <= self.data.output[0].length - 1) {
+      input = input.concat( createNullList( self.data.output[0].length - 1 - input.length ) );
+    }
+    else {
+      each(input, function(value, i){
+        if (self.data.output[0].length -1 < input.length) {
+          appendColumn.call(self, String( self.data.output[0].length ));
+        }
+      });
+    }
+
+    self.data.output.push( newRow.concat(input) );
   }
 
-  return this;
+  return self;
 }

--- a/src/dataset/lib/insert.js
+++ b/src/dataset/lib/insert.js
@@ -92,15 +92,6 @@ function insertRow(index, str, input){
     }
 
     self.data.output.splice(index, 0, newRow.concat(input) );
-
-    // each(self.output()[0], function(label, i){
-    //   var cell;
-    //   if (i > 0) {
-    //     cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
-    //     newRow.push(cell);
-    //   }
-    // });
-    // this.data.output.splice(index, 0, newRow);
   }
 
   return self;

--- a/src/dataset/lib/insert.js
+++ b/src/dataset/lib/insert.js
@@ -1,4 +1,9 @@
 var each = require("../../core/utils/each");
+var createNullList = require('../utils/create-null-list');
+var append = require('./append');
+
+var appendRow = append.appendRow,
+    appendColumn = append.appendColumn;
 
 module.exports = {
   "insertColumn": insertColumn,
@@ -27,14 +32,24 @@ function insertColumn(index, str, input){
   }
 
   else if (!input || input instanceof Array) {
-
     self.data.output[0].splice(index, 0, label);
-    each(self.output(), function(row, i){
-      var cell;
-      if (i > 0) {
-        cell = (input && input[i-1] !== "undefined") ? input[i-1] : null;
-        self.data.output[i].splice(index, 0, cell);
-      }
+    input = input || [];
+
+    if (input.length <= self.output().length - 1) {
+      input = input.concat( createNullList(self.output().length - 1 - input.length) );
+    }
+    else {
+      // If this new column is longer than existing columns,
+      // we need to update the rest to match ...
+      each(input, function(value, i){
+        if (self.data.output.length -1 < input.length) {
+          appendRow.call(self, String( self.data.output.length ));
+        }
+      });
+    }
+
+    each(input, function(value, i){
+      self.data.output[i+1].splice(index, 1, value);
     });
 
   }
@@ -63,15 +78,30 @@ function insertRow(index, str, input){
   }
 
   else if (!input || input instanceof Array) {
-    each(self.output()[0], function(label, i){
-      var cell;
-      if (i > 0) {
-        cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
-        newRow.push(cell);
-      }
-    });
-    this.data.output.splice(index, 0, newRow);
+    input = input || [];
+
+    if (input.length <= self.data.output[0].length - 1) {
+      input = input.concat( createNullList( self.data.output[0].length - 1 - input.length ) );
+    }
+    else {
+      each(input, function(value, i){
+        if (self.data.output[0].length -1 < input.length) {
+          appendColumn.call(self, String( self.data.output[0].length ));
+        }
+      });
+    }
+
+    self.data.output.splice(index, 0, newRow.concat(input) );
+
+    // each(self.output()[0], function(label, i){
+    //   var cell;
+    //   if (i > 0) {
+    //     cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
+    //     newRow.push(cell);
+    //   }
+    // });
+    // this.data.output.splice(index, 0, newRow);
   }
 
-  return this;
+  return self;
 }

--- a/src/dataset/lib/select.js
+++ b/src/dataset/lib/select.js
@@ -9,7 +9,7 @@ function selectColumn(q){
   var result = new Array(),
       index = (typeof q === 'number') ? q : this.data.output[0].indexOf(q);
 
-  if (index > -1) {
+  if (index > -1 && 'undefined' !== typeof this.data.output[0][index]) {
     each(this.data.output, function(row, i){
       result.push(row[index]);
     });
@@ -21,7 +21,7 @@ function selectRow(q){
   var result = new Array(),
       index = (typeof q === 'number') ? q : this.selectColumn(0).indexOf(q);
 
-  if (index > -1) {
+  if (index > -1 && 'undefined' !== typeof this.data.output[index]) {
     result = this.data.output[index];
   }
   return  result;

--- a/src/dataset/lib/set.js
+++ b/src/dataset/lib/set.js
@@ -1,7 +1,38 @@
+var each = require("../../core/utils/each");
+
+var append = require('./append');
+var select = require('./select');
+
 module.exports = {
   "set": set
 };
 
 function set(coords, value){
-  
+  if (arguments.length < 2 || coords.length < 2) {
+    throw Error('Incorrect arguments provided for #set method');
+  }
+
+  var colIndex = 'number' === typeof coords[0] ? coords[0] : this.data.output[0].indexOf(coords[0]),
+      rowIndex = 'number' === typeof coords[1] ? coords[1] : select.selectColumn.call(this, 0).indexOf(coords[1]);
+
+  var colResult = select.selectColumn.call(this, coords[0]), // this.data.output[0][coords[0]],
+      rowResult = select.selectRow.call(this, coords[1]);
+
+  // Column doesn't exist...
+  //  Let's create it and reset colIndex
+  if (colResult.length < 1) {
+    append.appendColumn.call(this, coords[0]);
+    colIndex = this.data.output[0].length-1;
+  }
+
+  // Row doesn't exist...
+  //  Let's create it and reset rowIndex
+  if (rowResult.length < 1) {
+    append.appendRow.call(this, coords[1]);
+    rowIndex = this.data.output.length-1;
+  }
+
+  // Set provided value
+  this.data.output[ rowIndex ][ colIndex ] = value;
+  return this;
 }

--- a/src/dataset/lib/set.js
+++ b/src/dataset/lib/set.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "set": set
+};
+
+function set(coords, value){
+  
+}

--- a/src/dataset/lib/update.js
+++ b/src/dataset/lib/update.js
@@ -1,4 +1,9 @@
 var each = require("../../core/utils/each");
+var createNullList = require('../utils/create-null-list');
+var append = require('./append');
+
+var appendRow = append.appendRow,
+    appendColumn = append.appendColumn;
 
 module.exports = {
   "updateColumn": updateColumn,
@@ -24,13 +29,23 @@ function updateColumn(q, input){
       });
 
     } else if (!input || input instanceof Array) {
+      input = input || [];
 
-      each(self.output(), function(row, i){
-        var cell;
-        if (i > 0) {
-          cell = (input && typeof input[i-1] !== "undefined" ? input[i-1] : null);
-          self.data.output[i][index] = cell;
-        }
+      if (input.length <= self.output().length - 1) {
+        input = input.concat( createNullList(self.output().length - 1 - input.length) );
+      }
+      else {
+        // If this new column is longer than existing columns,
+        // we need to update the rest to match ...
+        each(input, function(value, i){
+          if (self.data.output.length -1 < input.length) {
+            appendRow.call(self, String( self.data.output.length ));
+          }
+        });
+      }
+
+      each(input, function(value, i){
+        self.data.output[i+1][index] = value;
       });
 
     }
@@ -56,15 +71,22 @@ function updateRow(q, input){
       });
 
     } else if (!input || input instanceof Array) {
+      input = input || [];
 
-      each(self.output()[index], function(c, i){
-        var cell;
-        if (i > 0) {
-          cell = (input && input[i-1] !== undefined) ? input[i-1] : null;
-          self.data.output[index][i] = cell;
-        }
+      if (input.length <= self.data.output[0].length - 1) {
+        input = input.concat( createNullList( self.data.output[0].length - 1 - input.length ) );
+      }
+      else {
+        each(input, function(value, i){
+          if (self.data.output[0].length -1 < input.length) {
+            appendColumn.call(self, String( self.data.output[0].length ));
+          }
+        });
+      }
+
+      each(input, function(value, i){
+        self.data.output[index][i+1] = value;
       });
-
     }
 
   }

--- a/src/dataset/utils/create-null-list.js
+++ b/src/dataset/utils/create-null-list.js
@@ -1,0 +1,7 @@
+module.exports = function(len){
+  var list = new Array();
+  for (i = 0; i < len; i++) {
+    list.push(null);
+  }
+  return list;
+};

--- a/test/examples/dataset/index.html
+++ b/test/examples/dataset/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Dataset Demo | Keen IO</title>
+  <link rel='stylesheet' href='../dataviz/keen-bootstrap.min.css'>
+  <link rel='stylesheet' href='../dataviz/keen-dashboards.css'>
+  <!-- // <script src='./jquery-1.11.3.min.js'></script> -->
+
+  <!-- C3.js Deps -->
+  <link href='../dataviz/c3/c3.css' rel='stylesheet'>
+  <script src='../dataviz/c3/d3.js'></script>
+  <script src='../dataviz/c3/c3.js'></script>
+</head>
+<body>
+  <div class='container'>
+
+    <h3>Dataset Demo</h3>
+
+    <div class='row'>
+      <div class='col-sm-6'>
+        <div id='chart'></div>
+      </div>
+      <div class='col-sm-6'>
+        <!-- Demo Input -->
+        <select class="form-control" id="select-library">
+          <option value="google" selected="selected">Google Charts (default)</option>
+          <option value="c3">C3.js</option>
+          <!-- <option value="chartjs">Chart.js</option> -->
+        </select>
+        <hr>
+
+        <button class="btn btn-primary btn-block" id="btn-render">Render</button>
+
+        <br>
+        <pre id="dataset-output"></pre>
+      </div>
+    </div>
+
+  </div>
+
+  <script src='../../dist/keen.js'></script>
+  <script>
+
+    var btn = document.getElementById('btn-render'),
+        pre = document.getElementById('dataset-output'),
+        select = document.getElementById("select-library");
+
+    var chart = window.chart = new Keen.Dataviz()
+      .el(document.getElementById('chart'))
+      .dataType('cat-ordinal')
+      .height(250)
+      .prepare();
+
+    var dataset = new Keen.Dataset();
+    dataset.output([
+      ['index', 'Group A'],
+      ['1', 10],
+      ['2', 2],
+      ['3', 23],
+      ['4', 31],
+      ['5', 15]
+    ]);
+
+    btn.onclick = render;
+
+    function render(){
+      applySettings();
+      printDataset();
+      chart
+        .data(dataset)
+        .render();
+    }
+
+    function printDataset(){
+      var str = '[\n';
+      Keen.utils.each(dataset.output(), function(row, i){
+        if (i === 0) {
+          str += '  [ ' + row.join(',\t') + '\t\t]\n';
+        }
+        else {
+          str += '  [ ' + row.join(',\t\t') + '\t\t]\n';
+        }
+      });
+      str += '\n]';
+      pre.innerHTML = str;
+    }
+
+    function applySettings(){
+      var lib = select.options[select.selectedIndex].value;
+      var chartType = ('c3' === lib) ? 'line' : 'linechart';
+      chart
+        .destroy()
+        .chartType(chartType)
+        .chartOptions(null)
+        .library(lib);
+    }
+
+
+  </script>
+</body>
+<html>

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -494,6 +494,21 @@ describe("Keen.Dataset", function(){
         expect(this.ds.selectRow(1)).to.be.an("array")
           .and.to.deep.equal(["Total", null, null]);
       });
+      it("should extend other rows when the passed array is longer than other rows", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.insertRow(1, "Total", [123, 321, 323, null]);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal(["Total", 123, 321, 323, null]);
+        expect(this.ds.selectColumn(3)).to.be.an("array")
+          .and.to.deep.equal(["3", 323, null, null]);
+        expect(this.ds.selectColumn(4)).to.be.an("array")
+          .and.to.deep.equal(["4", null, null, null]);
+      });
     });
 
     describe("#updateRow", function() {
@@ -741,6 +756,23 @@ describe("Keen.Dataset", function(){
         expect(this.ds.selectColumn(1)).to.be.an("array")
           .and.to.deep.equal(["Total", null, null]);
       });
+
+      it("should extend other columns when passed array is longer than existing columns", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.insertColumn(1, "Total", [10, 10, 10, null]);
+        expect(this.ds.selectColumn(1)).to.be.an("array")
+          .and.to.deep.equal(["Total", 10, 10, 10, null]);
+        expect(this.ds.selectRow(3)).to.be.an('array')
+          .and.to.deep.equal(["3", 10, null, null]);
+        expect(this.ds.selectRow(4)).to.be.an('array')
+          .and.to.deep.equal(["4", null, null, null]);
+      });
+
     });
 
     describe("#updateColumn", function() {

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -388,6 +388,54 @@ describe("Keen.Dataset", function(){
 
   describe("Access Rows", function(){
 
+    describe("#set", function(){
+
+      it("should create a column and row when they don't already exist (integer)", function(){
+        this.ds.output([['index']]);
+        this.ds.set([1,1], 10);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal([1, 10]);
+      });
+
+      it("should create a column and row when they don't already exist (string)", function(){
+        this.ds.output([['index']]);
+        this.ds.set(['A','Row'], 10);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal(["Row", 10]);
+      });
+
+      it("should create multiple columns and rows in the proper order (integers)", function(){
+        this.ds.output([['index']]);
+        this.ds.set([1,1], 10);
+        this.ds.set([2,2], 10);
+        this.ds.set([1,3], 10);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal([1, 10, null]);
+        expect(this.ds.selectRow(2)).to.be.an("array")
+          .and.to.deep.equal([2, null, 10]);
+        expect(this.ds.selectRow(3)).to.be.an("array")
+          .and.to.deep.equal([3, 10, null]);
+        expect(this.ds.selectColumn(2)).to.be.an("array")
+          .and.to.deep.equal([2, null, 10, null]);
+      });
+
+      it("should create multiple columns and rows in the proper order (strings)", function(){
+        this.ds.output([['index']]);
+        this.ds.set(['A','Row 1'], 10);
+        this.ds.set(['B','Row 2'], 10);
+        this.ds.set(['A','Row 3'], 10);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal(["Row 1", 10, null]);
+        expect(this.ds.selectRow(2)).to.be.an("array")
+          .and.to.deep.equal(["Row 2", null, 10]);
+        expect(this.ds.selectRow(3)).to.be.an("array")
+          .and.to.deep.equal(["Row 3", 10, null]);
+        expect(this.ds.selectColumn(2)).to.be.an("array")
+          .and.to.deep.equal(["B", null, 10, null]);
+      });
+
+    });
+
     describe("#selectRow", function() {
       it("should return a given row", function(){
         var table = [["Index", "A", "B"],[0, 342, 664],[1, 353, 322]];

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -441,6 +441,19 @@ describe("Keen.Dataset", function(){
         expect(this.ds.selectRow(3)).to.be.an("array")
           .and.to.deep.equal([2, null, null]);
       });
+      it("should extend other rows when passed array is longer than existing rows", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.appendRow("new", [ 333, 222, 111 ]);
+        expect(this.ds.selectRow("new")).to.be.an("array")
+          .and.to.deep.equal(["new", 333, 222, 111]);
+        expect(this.ds.selectColumn(3)).to.be.an("array")
+          .and.to.deep.equal(["3", null, null, 111]);
+      });
     });
 
     describe("#insertRow", function() {
@@ -672,6 +685,21 @@ describe("Keen.Dataset", function(){
         this.ds.appendColumn("C", function(){});
         expect(this.ds.selectColumn(3)).to.be.an("array")
           .and.to.deep.equal(["C", null, null]);
+      });
+      it("should extend other columns when passed array is longer than existing columns", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.appendColumn("C", [123, 456, 789, 321]);
+        expect(this.ds.selectColumn(3)).to.be.an("array")
+          .and.to.deep.equal(["C", 123, 456, 789, 321]);
+        expect(this.ds.selectRow(3)).to.be.an('array')
+          .and.to.deep.equal(["3", null, null, 789]);
+        expect(this.ds.selectRow(4)).to.be.an('array')
+          .and.to.deep.equal(["4", null, null, 321]);
       });
     });
 

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -3,6 +3,8 @@ var expect = require("chai").expect;
 var Keen = require("../../../../src/core"),
     keenHelper = require("../../helpers/test-config");
 
+var each = require("../../../../src/core/utils/each");
+
 var data_extraction = require("./sample-data/extraction"),
     data_extraction_uneven = require("./sample-data/extraction-uneven")
     data_metric = require("./sample-data/metric"),
@@ -67,6 +69,7 @@ describe("Keen.Dataset", function(){
         records: "result",
         select: true
       });
+
       expect(dataset.output()).to.be.an("array")
         .and.to.be.of.length(56);
       expect(dataset.output()[0]).to.be.of.length(2);
@@ -89,6 +92,7 @@ describe("Keen.Dataset", function(){
           }
         ]
       });
+
       dataset.sortRows("desc", dataset.sum, 1);
       expect(dataset.output()).to.be.an("array")
         .and.to.be.of.length(4);
@@ -97,7 +101,7 @@ describe("Keen.Dataset", function(){
     });
 
     it("interval-groupBy-empties.json", function(){
-      var dataset = new Keen.Dataset()
+      var dataset = new Keen.Dataset();
       dataset.parse(data_interval_groupBy_empties, {
         records: "result",
         unpack: {
@@ -164,6 +168,7 @@ describe("Keen.Dataset", function(){
           }
         }
       });
+
       dataset.sortColumns("desc", dataset.sum, 1);
       dataset.sortRows("asc");
 
@@ -1123,6 +1128,209 @@ describe("Keen.Dataset", function(){
 
   });
 
+
+  describe("Parsing with #set", function() {
+
+    it("metric.json", function(){
+      var dataset = new Keen.Dataset();
+      dataset.set(['value', 'result'], data_metric.result);
+
+      expect(dataset.output())
+        .to.be.an("array")
+        .and.to.be.of.length(2);
+      expect(dataset.output()[0][0]).to.eql("index");
+      expect(dataset.output()[0][1]).to.eql("value");
+      expect(dataset.output()[1][0]).to.eql("result");
+      expect(dataset.output()[1][1]).to.eql(2450);
+    });
+
+    it("groupby.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_groupBy.result, function(record, i){
+        dataset.set(['result', record.page], record.result);
+      });
+
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(56);
+      expect(dataset.output()[0]).to.be.of.length(2);
+      expect(dataset.output()[0][0]).to.eql("index");
+      expect(dataset.output()[0][1]).to.eql("result");
+    });
+
+    it("groupBy-boolean.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_groupBy_boolean.result, function(record, i){
+        dataset.set([ 'result', String(record.switch) ], record.result);
+      });
+
+      dataset.sortRows("desc", dataset.sum, 1);
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(4);
+      expect(dataset.output()[1][0]).to.eql("true");
+      expect(dataset.output()[2][0]).to.eql("false");
+    });
+
+    it("interval-groupBy-empties.json", function(){
+      var dataset = new Keen.Dataset()
+      each(data_interval_groupBy_empties.result, function(record, i){
+        if (record.value.length) {
+          each(record.value, function(group, j){
+            dataset.set([ group['parsed_user_agent.os.family'] || '', record.timeframe.start ], group.result);
+          });
+        }
+        else {
+          dataset.appendRow(record.timeframe.start);
+        }
+      });
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(7);
+    });
+
+    it("interval-groupBy-boolean.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_interval_groupBy_boolean.result, function(record, i){
+        if (record.value.length) {
+          each(record.value, function(group, j){
+            dataset.set([ String(group.key) || '', record.timeframe.start ], group.result);
+          });
+        }
+        else {
+          dataset.appendRow(record.timeframe.start);
+        }
+      });
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(7);
+    });
+
+    it("interval-groupBy-nulls.json", function(){
+      var dataset = new Keen.Dataset()
+      each(data_interval_groupBy_nulls.result, function(record, i){
+        if (record.value.length) {
+          each(record.value, function(group, j){
+            dataset.set([ group['parsed_user_agent.os.family'] || '', record.timeframe.start ], group.result);
+          });
+        }
+        else {
+          dataset.appendRow(record.timeframe.start);
+        }
+      });
+
+      dataset.sortColumns("desc", dataset.sum, 1);
+      dataset.sortRows("asc");
+
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(7);
+      expect(dataset.output()[0]).to.be.of.length(3);
+      expect(dataset.output()[0][0]).to.eql("index");
+      expect(dataset.output()[0][1]).to.eql("");
+      expect(dataset.output()[0][2]).to.eql("Windows Vista");
+    });
+
+    it("extraction.json 1", function(){
+      var dataset = new Keen.Dataset();
+      each(data_extraction.result, function(record, i){
+        dataset
+          .set( [ 'Time', i+1 ], record.keen.timestamp )
+          .set( [ 'Page', i+1 ], record.page )
+          .set( [ 'Referrer', i+1 ], record.referrer )
+        // each(record.keen, function(value, key){
+        //   dataset.set([ key, i+1 ], value);
+        // });
+        // each(record, function(value, key){
+        //   if (key === 'keen') return;
+        //   dataset.set([ key, i+1 ], value);
+        // });
+      });
+      dataset.deleteColumn(0);
+
+      expect(dataset.output())
+        .to.be.an("array")
+        .and.to.be.of.length(data_extraction.result.length+1);
+      expect(dataset.output()[0]).to.be.of.length(3);
+      expect(dataset.output()[0][0]).to.eql("Time");
+      expect(dataset.output()[0][1]).to.eql("Page");
+      expect(dataset.output()[0][2]).to.eql("Referrer");
+    });
+
+    // it("extraction.json 2", function(){
+    //   var dataset = new Keen.Dataset();
+    //   each(data_extraction.result, function(record, i){
+    //     dataset
+    //       .set( [ 'keen.timestamp', i+1 ], record.keen.timestamp )
+    //       .set( [ 'page', i+1 ], record.page )
+    //       .set( [ 'referrer', i+1 ], record.referrer )
+    //   });
+    //   dataset.deleteColumn(0);
+    //
+    //   expect(dataset.output()).to.be.an("array")
+    //     .and.to.be.of.length(data_extraction.result.length+1);
+    //   expect(dataset.output()[0]).to.be.of.length(3);
+    //   expect(dataset.output()[0][0]).to.eql("keen.timestamp");
+    //   expect(dataset.output()[0][1]).to.eql("page");
+    //   expect(dataset.output()[0][2]).to.eql("referrer");
+    // });
+
+
+    it("extraction-uneven.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_extraction_uneven.result, function(record, i){
+        dataset
+          .set( [ 'keen.timestamp', i+1 ], (record.keen ? record.keen.timestamp : null ) )
+          .set( [ 'page', i+1 ], record.page || null )
+          .set( [ 'key', i+1 ], record.key || null )
+      });
+      dataset.deleteColumn(0);
+
+      expect(dataset.output())
+        .to.be.an("array")
+        .and.to.be.of.length(data_extraction_uneven.result.length+1);
+    });
+
+
+    // it("extraction-uneven.json SELECT ALL", function(){
+    //   var dataset = new Keen.Dataset().parse(data_extraction_uneven, {
+    //     records: "result",
+    //     select: true
+    //   });
+    //   dataset.sortRows("asc");
+    //   expect(dataset.output())
+    //     .to.be.an("array")
+    //     .and.to.be.of.length(data_extraction_uneven.result.length+1);
+    //   expect(dataset.output()[0]).to.be.of.length(7);
+    //   expect(dataset.output()[0][0]).to.eql("keen.timestamp");
+    // });
+
+
+    it("funnel.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_funnel.result, function(record, i){
+        dataset.set( [ 'step', data_funnel.steps[i].event_collection ], record );
+      });
+
+      expect(dataset.output())
+        .to.be.an("array")
+        .and.to.be.of.length(6);
+      expect(dataset.output()[0][0]).to.eql("index");
+      expect(dataset.output()[0][1]).to.eql("step");
+      expect(dataset.output()[1][0]).to.be.eql("pageview");
+      expect(dataset.output()[1][1]).to.be.eql(42);
+    });
+
+
+    it("interval-double-groupBy.json", function(){
+      var dataset = new Keen.Dataset();
+      each(data_interval_double_groupBy.result, function(record, i){
+        each(record.value, function(group, j){
+          var label = group["first.property"] + " " + group["second.property"];
+          dataset.set( [ label, record.timeframe.start ], group.result );
+        });
+      });
+
+      expect(dataset.output()).to.be.an("array")
+        .and.to.be.of.length(4);
+    });
+
+  });
 
 
 });

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -551,6 +551,19 @@ describe("Keen.Dataset", function(){
         expect(this.ds.selectRow(1)).to.be.an("array")
           .and.to.deep.equal([1, 695, 986]);
       });
+      it("should extend other rows when passed array is longer than existing rows", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.updateRow(1, [10, 10, null, null]);
+        expect(this.ds.selectRow(1)).to.be.an("array")
+          .and.to.deep.equal([0, 10,10,null,null]);
+        expect(this.ds.selectColumn(3)).to.be.an("array")
+          .and.to.deep.equal(["3", null, null]);
+      });
     });
 
     describe("#deleteRow", function() {

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -813,6 +813,21 @@ describe("Keen.Dataset", function(){
         expect(this.ds.selectColumn(1)).to.be.an("array")
           .and.to.deep.equal(["A", 1006, 675]);
       });
+      it("should extend other columns when passed array is longer than existing columns", function(){
+        var table = [
+          ["Index", "A", "B"],
+          [0, 342, 664],
+          [1, 353, 322]
+        ];
+        this.ds.output(table);
+        this.ds.updateColumn(1, [10, 10, null, null]);
+        expect(this.ds.selectColumn(1)).to.be.an("array")
+          .and.to.deep.equal(["A", 10, 10, null, null]);
+        expect(this.ds.selectColumn(2)).to.be.an("array")
+          .and.to.deep.equal(["B", 664, 322, null, null]);
+        expect(this.ds.selectRow(3)).to.be.an("array")
+          .and.to.deep.equal(["3", null, null]);
+      });
     });
 
     describe("#deleteColumn", function() {


### PR DESCRIPTION
These updates resolve a lot of pain points with `Keen.Dataset`.

**Part 1**

`.appendColumn/Row`, `.insertColumn/Row`, and `.updateColumn/Row` methods now accept an unbounded number of values. If you insert a new column with 7 values and all other existing columns only have 3 values the write will succeed and all other columns will be extended with cells containing null values. This makes it extremely easy to build out dataset instances manually, and will be an integral part of a new technique for parsing complex queries.

**Part 2**

A new `.set` method plots values into the dataset table, creating columns and rows if they don't exist. **Part 1** of this PR paved the way for intelligently handling empty space and overages. Together, these additions let you scaffold out datasets without needing to manage column headers, row indices, or manually managing empty space. It just works.

Example:

```javascript
// Initial state:
[
  [ "index", "A" ],
  [ "row 1", 432 ],
  [ "row 2", 343 ]
]

// Set new values to specified cells:
dataset.set(["A", "row 1"], 10);
dataset.set(["B", "row 2"], 332);

// New state:
[
  [ "index", "A", "B" ],
  [ "row 1", 10, null ],
  [ "row 2", 343, 332 ]
]
```