### PR TITLE
Fix Dataset bug

### DIFF
--- a/src/dataset/lib/append.js
+++ b/src/dataset/lib/append.js
@@ -26,7 +26,6 @@ function appendColumn(str, input){
   }
 
   else if (!input || input instanceof Array) {
-    self.data.output[0].push(label);
     input = input || [];
 
     if (input.length <= self.output().length - 1) {
@@ -42,6 +41,7 @@ function appendColumn(str, input){
       });
     }
 
+    self.data.output[0].push(label);
     each(input, function(value, i){
       self.data.output[i+1][self.data.output[0].length-1] = value;
     });

--- a/src/dataset/lib/insert.js
+++ b/src/dataset/lib/insert.js
@@ -49,7 +49,7 @@ function insertColumn(index, str, input){
     }
 
     each(input, function(value, i){
-      self.data.output[i+1].splice(index, 1, value);
+      self.data.output[i+1].splice(index, 0, value);
     });
 
   }

--- a/src/dataset/lib/insert.js
+++ b/src/dataset/lib/insert.js
@@ -32,7 +32,6 @@ function insertColumn(index, str, input){
   }
 
   else if (!input || input instanceof Array) {
-    self.data.output[0].splice(index, 0, label);
     input = input || [];
 
     if (input.length <= self.output().length - 1) {
@@ -48,6 +47,7 @@ function insertColumn(index, str, input){
       });
     }
 
+    self.data.output[0].splice(index, 0, label);
     each(input, function(value, i){
       self.data.output[i+1].splice(index, 0, value);
     });

--- a/test/unit/modules/dataset/dataset-spec.js
+++ b/test/unit/modules/dataset/dataset-spec.js
@@ -833,6 +833,8 @@ describe("Keen.Dataset", function(){
         this.ds.insertColumn(1, "Total", [10, 10, 10, null]);
         expect(this.ds.selectColumn(1)).to.be.an("array")
           .and.to.deep.equal(["Total", 10, 10, 10, null]);
+        expect(this.ds.selectRow(2)).to.be.an('array')
+          .and.to.deep.equal([1, 10, 353, 322]);
         expect(this.ds.selectRow(3)).to.be.an('array')
           .and.to.deep.equal(["3", 10, null, null]);
         expect(this.ds.selectRow(4)).to.be.an('array')


### PR DESCRIPTION
Found a small glitch where `.insertColumn` deleted subsequent cell for each row. The second argument of `.splice` (below) was changed from `1` to `0` (insert, not overwrite):

```javascript
each(input, function(value, i){
  self.data.output[i+1].splice(index, 0, value);
});
```