### PR TITLE
Add additional checks when inferring dataType in "parseRawData"

### DIFF
--- a/src/dataviz/lib/parseRawData.js
+++ b/src/dataviz/lib/parseRawData.js
@@ -118,7 +118,7 @@ function parseRawData(response){
 
     // Funnel
     // -------------------------------
-    if (typeof response.result[0] == 'number'){
+    if (typeof response.result[0] == 'number' && typeof response.result.steps !== "undefined"){
       dataType = 'cat-ordinal';
       schema = {
         records: '',
@@ -137,7 +137,7 @@ function parseRawData(response){
 
     // Select Unique
     // -------------------------------
-    if (typeof response.result[0] == 'string'){
+    if (typeof response.result[0] == 'string' || typeof response.result[0] == 'number'){
       dataType = 'nominal';
       dataset = new Dataset();
       dataset.appendColumn('unique values', []);


### PR DESCRIPTION
#### What's this PR do?

When inferring the `dataType`, `dataset`, and `schema` for a
`select_unique` query response, keen-js breaks.
`parseRawData` can't find a "target property" because it's identifying
some `select_unique` queries as a "Funnel" `dataType`.

PR adds a few more checks in `parseRawData` to prevent that error from
happening. Originally I wanted to refactor parseRawData to take an
analysis type from the query and to make future testing easier, but
I'm still unfamiliar with a lot of the other types of queries we can
run on explorer, so I am saving that for a later date. The WIP branch
for those changes are in `jc-parse-result-refactor`.

#### Where should the reviewer start?

* look at `src/dataviz/lib/parseRawData.js`

#### How should this be manually tested?

* Go to explorer, start creating a `select_unique` query, and select a target
property that is a number type (ex: customer ids)

#### What are the relevant tickets?

https://github.com/keenlabs/data-tools/issues/283