### PR TITLE
Fix double callback issue

### DIFF
--- a/src/core/request.js
+++ b/src/core/request.js
@@ -40,6 +40,9 @@ Request.prototype.refresh = function(){
       errored = false;
 
   var handleResponse = function(err, res, index){
+    if (errored) {
+      return;
+    }
     if (err) {
       self.trigger("error", err);
       if (self.callback) {

--- a/test/unit/modules/core/request/server-spec.js
+++ b/test/unit/modules/core/request/server-spec.js
@@ -89,7 +89,7 @@ describe("Keen.Request", function() {
       it('should return a single error when unsuccessful', function(done){
         var response = { error_code: "ResourceNotFoundError", message: "no foo" };
         mock.post("/queries/count", 500, JSON2.stringify(response));
-        mock.post("/queries/count", 200, JSON2.stringify({ result: 1 }));
+        mock.post("/queries/count", 500, JSON2.stringify(response));
         mock.post("/queries/count", 200, JSON2.stringify({ result: 1 }));
         this.client.run([this.query, this.query, this.query], function(err, res){
           expect(err).to.exist;


### PR DESCRIPTION
#### What does this PR do?

Fix double callback issue when using client.run with multiple failing queries.

#### How should this be manually tested? (if appropriate)

* run `gulp with-tests`
* tests run at `localhost:9999/`

#### Are there any related issues open?
#312 