### PR TITLE
add absolute timeframe to query docs

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -27,7 +27,10 @@ Keen.ready(function(){
   // Count the number of times case study pages were viewed
   var count = new Keen.Query("count", {
     eventCollection: "pageviews",
-    timeframe: "this_7_days",
+    timeframe: {
+      "start":"2015-07-01T07:00:00.000Z",
+      "end":"2015-08-01T07:00:00.000Z"
+    },
     interval: "daily",
     maxAge: 300, // activate query caching by assigning maxAge (an integer representing seconds)
     filters: [


### PR DESCRIPTION
#### What does this PR do?

This adds an example query to `docs/query.md` that uses an absolute timeframe.

#### How should this be manually tested? (if appropriate)

Run JS code example and make sure the sample query is valid.

#### Are there any related issues open?

https://github.com/keen/keen-js/issues/315