### PR TITLE
Remove trailing comma from dataset/index.js

### DIFF
--- a/src/dataset/index.js
+++ b/src/dataset/index.js
@@ -12,7 +12,7 @@ extend(Dataset.prototype, require("./lib/update"));
 
 extend(Dataset.prototype, require("./lib/analyses"));
 extend(Dataset.prototype, {
-  "format": require("./lib/format"),
+  "format": require("./lib/format")
 });
 
 module.exports = Dataset;


### PR DESCRIPTION
Fixes https://github.com/keen/keen-js/issues/318