### PR TITLE
Fix #332, preserve functions passed into chartOptions config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **Important:** v3.2.0 introduced several breaking changes from previous versions. Check out the [Changelog](./CHANGELOG.md#3.2.0) before upgrading.
 
-**Charts issue:** A recent update to the Google Visualization API is causing charts to fail in earlier versions of this library. To resolve the issue, simply update from v3.0.x to [v3.1.0](https://d26b395fwzu5fz.cloudfront.net/3.1.0/keen.js). This is a safe upgrade with no breaking changes from earlier affected versions. Read about this release [here](https://github.com/keen/keen-js/releases/tag/v3.1.0).
 <!--
 [![Build Status](https://api.travis-ci.org/keen/keen-js.png?branch=master)](https://travis-ci.org/keen/keen-js) [![Selenium Test Status](https://saucelabs.com/buildstatus/keenlabs-js)](https://saucelabs.com/u/keenlabs-js)
 -->
@@ -10,8 +9,6 @@
 ## Documentation
 
 Docs have been moved into the master branch, so they stay in sync with each release. Check out the latest [here](./docs).
-
-v3.1.0 docs are [here](https://github.com/keen/keen-js/tree/v3.1.0/docs), and v2 docs are [way back here](https://github.com/keen/keen-js/tree/v2).
 
 
 ## Get Project ID & API Keys

--- a/src/dataviz/extensions/draw.js
+++ b/src/dataviz/extensions/draw.js
@@ -7,22 +7,7 @@ module.exports = function(query, el, cfg) {
   var DEFAULTS = clone(Dataviz.defaults),
       visual = new Dataviz(),
       request = new Request(this, [query]),
-      config = cfg ? clone(cfg) : {};
-
-  if (config.chartType) {
-    visual.chartType(config.chartType);
-    delete config.chartType;
-  }
-
-  if (config.library) {
-    visual.library(config.library);
-    delete config.library;
-  }
-
-  if (config.chartOptions) {
-    visual.chartOptions(config.chartOptions);
-    delete config.chartOptions;
-  }
+      config = cfg || {};
 
   visual
     .attributes(extend(DEFAULTS, config))

--- a/src/dataviz/lib/attributes.js
+++ b/src/dataviz/lib/attributes.js
@@ -1,14 +1,23 @@
 var each = require("../../core/utils/each");
-var chartOptions = require("./chartOptions");
+var chartOptions = require("./chartOptions")
+    chartType = require("./chartType"),
+    library = require("./library");
 
 module.exports = function(obj){
   if (!arguments.length) return this.view["attributes"];
   var self = this;
   each(obj, function(prop, key){
-    if (key === "chartOptions") {
+    // Handle specified options differently
+    if (key === "library") {
+      library.call(self, prop);
+    }
+    else if (key === "chartType") {
+      chartType.call(self, prop);
+    }
+    else if (key === "chartOptions") {
       chartOptions.call(self, prop);
-      // self.chartOptions(prop);
-    } else {
+    }
+    else {
       self.view["attributes"][key] = prop;
     }
   });

--- a/test/examples/dataviz/c3/index.html
+++ b/test/examples/dataviz/c3/index.html
@@ -132,17 +132,23 @@
     readKey: '4e4d72e5bf8b69686ed87a5a9671bba7ad829fbd10a1c281ee51b6e9c1ce9548e941e1f336f9de9281a5acc66ca8fdabc9b3c806e390eca01665f6a308a9b03d8b332b3fbd9f3cdfc3b3e16b0da6d84851e53fe20fbbce300801b8a401a6395b9f4ab9c89bff566e9678a74ca6624f9b'
   });
 
+  var count = new Keen.Query('count', {
+    eventCollection: 'pageviews',
+    timeframe: 'this_12_months',
+    groupBy: 'user.device_info.browser.family'
+  })
+
   var interval = new Keen.Query('count', {
     eventCollection: 'pageviews',
-    timeframe: 'this_2_months',
-    interval: 'weekly'
+    timeframe: 'this_12_months',
+    interval: 'monthly'
   });
 
   var multiline = new Keen.Query('count', {
     event_collection: 'pageviews',
     group_by: 'user.device_info.browser.family',
-    timeframe: 'this_2_months',
-    interval: 'weekly'
+    timeframe: 'this_12_months',
+    interval: 'monthly'
   });
 
   var labelMap = {
@@ -174,18 +180,28 @@
     .title('Percentage of awesome')
     .render();
 
-  var c3donut = new Keen.Dataviz()
-    //.library('c3')
-    //.chartType('donut')
-    .el(document.getElementById('c3-donut'))
-    .parseRawData({ result: [
-        { label: 'A', result: 9 },
-        { label: 'B', result: 7 },
-        { label: 'C', result: 4 }
-      ]
-    })
-    //.title('Best Donut!')
-    .render();
+  // var c3donut = new Keen.Dataviz()
+  //   //.library('c3')
+  //   //.chartType('donut')
+  //   .el(document.getElementById('c3-donut'))
+  //   .parseRawData({ result: [
+  //       { label: 'A', result: 9 },
+  //       { label: 'B', result: 7 },
+  //       { label: 'C', result: 4 }
+  //     ]
+  //   })
+  //   //.title('Best Donut!')
+  //   .render();
+
+  client.draw(count, document.getElementById('c3-donut'), {
+    library: 'c3',
+    chartType: 'donut',
+    chartOptions: {
+      test: function(a,b,c){
+        console.log(a,b,c);
+      }
+    }
+  });
 
   var c3pie = new Keen.Dataviz()
     .library('c3')

--- a/test/examples/dataviz/c3/index.html
+++ b/test/examples/dataviz/c3/index.html
@@ -197,9 +197,7 @@
     library: 'c3',
     chartType: 'donut',
     chartOptions: {
-      test: function(a,b,c){
-        console.log(a,b,c);
-      }
+      
     }
   });
 


### PR DESCRIPTION
This PR removes the use of `clone()` from `client.draw()`, and moves config option handling logic into the `chart.attributes()` method.

Fixes #332