### PR TITLE
Check context before trying to get XHR object

### DIFF
--- a/src/core/utils/sendQuery.js
+++ b/src/core/utils/sendQuery.js
@@ -17,7 +17,7 @@ module.exports = function(path, params, callback){
     return;
   }
 
-  if (getXHR() || getContext() === 'server' ) {
+  if (getContext() === 'server' || getXHR()) {
     request
       .post(url)
         .set('Content-Type', 'application/json')


### PR DESCRIPTION
When running our ES6-based app in Node 5.x, `getXHR()` fails because `this` is `undefined`:

```
TypeError: Cannot read property 'XMLHttpRequest' of undefined
  at module.exports (/path/to/node_modules/keen-js/src/core/helpers/get-xhr-object.js:4:11)
  // ...
```

If the app is compiled into ES5 with babel, keen-js works just fine. An easy fix is to check the context first and only get XHR object if running in browser context.

Unfortunately I don't have a minimalistic test case for you at the moment.