### PR TITLE
correct chart type example

### DIFF
--- a/src/dataviz/README.md
+++ b/src/dataviz/README.md
@@ -272,7 +272,7 @@ chart.library(); // returns current library selection
 #### .chartType(string)
 
 ```javascript
-chart.chartType("bar");
+chart.chartType("barchart");
 chart.chartType(); // returns current chartType selection
 ```
 


### PR DESCRIPTION
when testing I received an "Incorrect chartType" error when setting chart.chartType("bar") while chart.chartType("barchart") works. This also seems to be more aligned with other documentation.