### PR TITLE
Fix Browserify/Versionify bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 <a name="unreleased"></a>
 # Unreleased
 -->
+<a name="4.0.1"></a>
+# Fix Package Dependencies
+
+**Fixed:**
+* Removed unnecessary `browserify.transform` definition from `package.json`
+
+
 <a name="4.0.0"></a>
 # Hello, version 4
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Or load it synchronously from the CDN:
 
 ```html
 <meta charset="utf-8">
-<link href="https://d26b395fwzu5fz.cloudfront.net/4.0.0/keen.min.css" rel="stylesheet" />
-<script src="https://d26b395fwzu5fz.cloudfront.net/4.0.0/keen.min.js"></script>
+<link href="https://d26b395fwzu5fz.cloudfront.net/4.0.1/keen.min.css" rel="stylesheet" />
+<script src="https://d26b395fwzu5fz.cloudfront.net/4.0.1/keen.min.js"></script>
 ```
 
 Under the hood, this is simply a bundled release of the following packages:
@@ -147,6 +147,11 @@ Every event that is recorded will inherit this baseline data model. Additional p
 * [Extend event data models for a single event stream](https://github.com/keen/keen-tracking.js/blob/master/docs/extend-events.md)
 * [Queue events to be recorded at a given time interval](https://github.com/keen/keen-tracking.js/blob/master/docs/defer-events.md)
 
+**React Examples**
+
+* [React Flux Logger](https://github.com/keen/keen-tracking.js/tree/master/docs/examples/react-flux): How to instrument a Flux ReduceStore
+* [React Redux Middleware](https://github.com/keen/keen-tracking.js/tree/master/docs/examples/react-redux-middleware): How to instrument a Redux Store
+
 **Documentation:** [Full documentation is available in the keen-tracking.js repo](https://github.com/keen/keen-tracking.js/blob/master/docs/README.md).
 
 ---
@@ -214,8 +219,8 @@ This package contains [keen-dataviz.js](https://github.com/keen/keen-analysis.js
 <html>
   <head>
     <meta charset="utf-8">
-    <link href="https://d26b395fwzu5fz.cloudfront.net/4.0.0/keen.min.css" rel="stylesheet" />
-    <script src="https://d26b395fwzu5fz.cloudfront.net/4.0.0/keen.min.js"></script>
+    <link href="https://d26b395fwzu5fz.cloudfront.net/4.0.1/keen.min.css" rel="stylesheet" />
+    <script src="https://d26b395fwzu5fz.cloudfront.net/4.0.1/keen.min.js"></script>
   </head>
   <body>
     <!-- DOM Element -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keen-js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "main": "lib/index.js",
   "style": "style/index.css",
@@ -18,11 +18,6 @@
     "Dustin Larimer <dustin@keen.io> (https://github.com/dustinlarimer)",
     "Joanne Cheng <joanne@keen.io> (http://joannecheng.me)"
   ],
-  "browserify": {
-    "transform": [
-      "browserify-versionify"
-    ]
-  },
   "dependencies": {
     "keen-analysis": "1.3.0",
     "keen-dataviz": "1.1.3",


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue where an unnecessary `browserify.transform` definition left over from keen-js v3.x causes browserify to throw errors. 

This PR also adds a few links to new React example content in keen-tracking.js: https://github.com/keen/keen-tracking.js/tree/master/docs#examples